### PR TITLE
set version to 1.0.5-SNAPSHOT

### DIFF
--- a/jlatexmath-example-export/pom.xml
+++ b/jlatexmath-example-export/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scilab.forge</groupId>
 		<artifactId>jlatexmath-parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.5-SNAPSHOT</version>
 	</parent>
 	<artifactId>jlatexmath-example-export</artifactId>
 	<packaging>jar</packaging>

--- a/jlatexmath-example-giws/pom.xml
+++ b/jlatexmath-example-giws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scilab.forge</groupId>
         <artifactId>jlatexmath-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
     <artifactId>jlatexmath-example-giws</artifactId>
     <packaging>jar</packaging>

--- a/jlatexmath-font-cyrillic/pom.xml
+++ b/jlatexmath-font-cyrillic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scilab.forge</groupId>
         <artifactId>jlatexmath-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
     <artifactId>jlatexmath-font-cyrillic</artifactId>
     <packaging>jar</packaging>

--- a/jlatexmath-font-greek/pom.xml
+++ b/jlatexmath-font-greek/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scilab.forge</groupId>
         <artifactId>jlatexmath-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
     <artifactId>jlatexmath-font-greek</artifactId>
     <packaging>jar</packaging>

--- a/jlatexmath-fop/pom.xml
+++ b/jlatexmath-fop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scilab.forge</groupId>
         <artifactId>jlatexmath-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
     <artifactId>jlatexmath-fop</artifactId>
     <packaging>jar</packaging>

--- a/jlatexmath/pom.xml
+++ b/jlatexmath/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scilab.forge</groupId>
         <artifactId>jlatexmath-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
     <artifactId>jlatexmath</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <!--<groupId>org.scilab.forge</groupId> -->
     <groupId>org.scilab.forge</groupId>
     <artifactId>jlatexmath-parent</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>parent pom for jlatexmath artifacts</description>
     <packaging>pom</packaging>


### PR DESCRIPTION
Recently merged Maven rework #13 had version at 1.0.7-SNAPSHOT but as next release is 1.0.5 have set versions of poms to 1.0.5-SNAPSHOT.