### PR TITLE
setup pom.xml files for nexus deployment

### DIFF
--- a/jlatexmath-example-export/pom.xml
+++ b/jlatexmath-example-export/pom.xml
@@ -1,45 +1,58 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.scilab.forge</groupId>
-		<artifactId>jlatexmath-parent</artifactId>
-		<version>1.0.5-SNAPSHOT</version>
-	</parent>
-	<artifactId>jlatexmath-example-export</artifactId>
-	<packaging>jar</packaging>
+    <parent>
+        <groupId>org.scilab.forge</groupId>
+        <artifactId>jlatexmath-parent</artifactId>
+        <version>1.0.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>jlatexmath-example-export</artifactId>
+    <packaging>jar</packaging>
 
-	<name>${project.artifactId}</name>
-	<description>Examples of exporting latex formulas as PNG, PDF, SVG, EPS</description>
+    <name>${project.artifactId}</name>
+    <description>Examples of exporting latex formulas as PNG, PDF, SVG, EPS</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>${project.parent.groupId}</groupId>
-			<artifactId>jlatexmath</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>fop</artifactId>
-			<version>${fop.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>batik-codec</artifactId>
-			<version>1.7</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.xmlgraphics</groupId>
-			<artifactId>xmlgraphics-commons</artifactId>
-			<version>2.1</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>jlatexmath</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>fop</artifactId>
+            <version>${fop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-codec</artifactId>
+            <version>1.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>xmlgraphics-commons</artifactId>
+            <version>2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus.staging.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/jlatexmath-example-giws/pom.xml
+++ b/jlatexmath-example-giws/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.scilab.forge</groupId>
         <artifactId>jlatexmath-parent</artifactId>
@@ -12,18 +12,31 @@
 
     <name>${project.artifactId}</name>
     <description>TODO</description>
-    
+
     <dependencies>
-		<dependency>
-			<groupId>${project.parent.groupId}</groupId>
-			<artifactId>jlatexmath</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>jlatexmath</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
-        </dependency>       
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus.staging.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jlatexmath-ignore/pom.xml
+++ b/jlatexmath-ignore/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.scilab.forge</groupId>
+        <artifactId>jlatexmath-parent</artifactId>
+        <version>1.0.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>jlatexmath-ignore</artifactId>
+    <packaging>pom</packaging>
+
+    <name>${project.artifactId}</name>
+    <description>only required to prevent example/test modules from being deployed to sonatype</description>
+
+    <dependencies>
+        <!-- use dependencies to ensure that is the last module deployed -->
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>jlatexmath-example-export</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>jlatexmath-example-giws</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
         <junit.version>4.12</junit.version>
         <jar.plugin.version>3.0.2</jar.plugin.version>
         <build.helper.plugin.version>1.12</build.helper.plugin.version>
+        <!-- nexus staging version should match the one used in sonatype-parent -->
+        <nexus.staging.plugin.version>1.6.5</nexus.staging.plugin.version>
         <scm.url>scm:git:https://github.com/opencollabnet/jlatexmath.git</scm.url>
     </properties>
 
@@ -57,6 +59,9 @@
         <module>jlatexmath-fop</module>
         <module>jlatexmath-example-giws</module>
         <module>jlatexmath-example-export</module>
+        <!-- require a dummy artifact so can ignore deployment of previous two example modules -->
+        <!-- see https://issues.sonatype.org/browse/NEXUS-9138 -->
+        <module>jlatexmath-ignore</module>
     </modules>
 
     <build>


### PR DESCRIPTION
* a few changes to the pom to configure which artifacts are deployed
* changed tabs to spaces in pom.xml files

Note that there is now a *jlatexmath-ignore* pom artifact which is the only workaround for *nexus-staging-maven-plugin* that ensures that the example artifacts (*jlatexmath-example-export* and *jlatexmath-example-giws*) do not get deployed to maven central. See https://issues.sonatype.org/browse/NEXUS-9138 for more info. The *jlatexmath-ignore* artifact will get deployed but is pom only.