### PR TITLE
update CHANGELOG with release information

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-jlatexmath (1.0.6)
+jlatexmath (1.0.5)
 	* Remove ligatures info for cyrillic
 
 	* Add italic correction only in math mode.
@@ -9,7 +9,6 @@ jlatexmath (1.0.6)
 
 	* Italic correction was not taken into account when making box for a CharSymbol.
 
-jlatexmath (1.0.5)
 	* Support ~ as non breakable space.
 
 jlatexmath (1.0.4)


### PR DESCRIPTION
I've released jlatexmath as  1.0.5 to Maven Central.

Unfortunately I see that the CHANGELOG already references 1.0.5 and 1.0.6 (but we didn't have tags nor deployed artifacts in Maven Central). I've edited the CHANGELOG so that 1.0.5 combines what was documented as part of 1.0.5 and 1.0.6.