### PR TITLE
add jmh benchmark to measure perf of parsing and rendering latex

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ Have fun and if you meet any problem, don't hesitate to create a new issue on gi
 
 ## License
 Regarding JLaTeXMath’s Classpath Exception and JavaScript: If you use the Google Web Toolkit (GWT) to compile JLaTeXMath to an “executable” (in JavaScript) you can then include/link this “executable” JavaScript library on a website or inside another program. In this case the rest of the website/program need not be licensed under the GPL.
+
+## Benchmarks
+To run jmh benchmarks (measuring parse and render performance):
+    # benchmarks are in core module
+    cd jlatexmath
+    mvn clean install -P benchmark

--- a/jlatexmath/pom.xml
+++ b/jlatexmath/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -10,6 +11,9 @@
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <description>A Java API to render LaTeX</description>
+    <properties>
+        <jmh.version>1.19</jmh.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -26,6 +30,18 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -69,4 +85,45 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>benchmark</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>run-benchmarks</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <classpathScope>test</classpathScope>
+                                    <executable>java</executable>
+                                    <arguments>
+                                        <argument>-classpath</argument>
+                                        <classpath />
+                                        <argument>org.openjdk.jmh.Main</argument>
+                                        <!-- -h for help -->
+                                        <argument>-f</argument>
+                                        <argument>1</argument>
+                                        <argument>-i</argument>
+                                        <argument>10</argument>
+                                        <argument>-wi</argument>
+                                        <argument>5</argument>
+                                        <argument>-jvmArgs</argument>
+                                        <argument>-Xmx512m</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/Benchmarks.java
+++ b/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/Benchmarks.java
@@ -1,0 +1,53 @@
+package org.scilab.forge.jlatexmath;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.image.BufferedImage;
+
+import javax.swing.JLabel;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class Benchmarks {
+
+    private static final String LATEX_1 = createLatex1();
+
+    @Benchmark
+    public BufferedImage parseAndRenderLatex() {
+        TeXFormula formula = new TeXFormula(LATEX_1);
+        TeXIcon icon = formula.new TeXIconBuilder().setStyle(TeXConstants.STYLE_DISPLAY).setSize(20)
+                .build();
+        icon.setInsets(new Insets(5, 5, 5, 5));
+
+        BufferedImage image = new BufferedImage(icon.getIconWidth(), icon.getIconHeight(),
+                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = image.createGraphics();
+        g2.setColor(Color.white);
+        g2.fillRect(0, 0, icon.getIconWidth(), icon.getIconHeight());
+        JLabel jl = new JLabel();
+        jl.setForeground(new Color(0, 0, 0));
+        icon.paintIcon(jl, g2, 0, 0);
+        // must return the image to avoid dead code elimination
+        return image;
+    }
+
+    private static String createLatex1() {
+        // taken from Example2
+        String latex = "\\begin{array}{l}";
+        latex += "\\forall\\varepsilon\\in\\mathbb{R}_+^*\\ \\exists\\eta>0\\ |x-x_0|\\leq\\eta\\Longrightarrow|f(x)-f(x_0)|\\leq\\varepsilon\\\\";
+        latex += "\\det\\begin{bmatrix}a_{11}&a_{12}&\\cdots&a_{1n}\\\\a_{21}&\\ddots&&\\vdots\\\\\\vdots&&\\ddots&\\vdots\\\\a_{n1}&\\cdots&\\cdots&a_{nn}\\end{bmatrix}\\overset{\\mathrm{def}}{=}\\sum_{\\sigma\\in\\mathfrak{S}_n}\\varepsilon(\\sigma)\\prod_{k=1}^n a_{k\\sigma(k)}\\\\";
+        latex += "\\sideset{_\\alpha^\\beta}{_\\gamma^\\delta}{\\begin{pmatrix}a&b\\\\c&d\\end{pmatrix}}\\\\";
+        latex += "\\int_0^\\infty{x^{2n} e^{-a x^2}\\,dx} = \\frac{2n-1}{2a} \\int_0^\\infty{x^{2(n-1)} e^{-a x^2}\\,dx} = \\frac{(2n-1)!!}{2^{n+1}} \\sqrt{\\frac{\\pi}{a^{2n+1}}}\\\\";
+        latex += "\\int_a^b{f(x)\\,dx} = (b - a) \\sum\\limits_{n = 1}^\\infty  {\\sum\\limits_{m = 1}^{2^n  - 1} {\\left( { - 1} \\right)^{m + 1} } } 2^{ - n} f(a + m\\left( {b - a} \\right)2^{-n} )\\\\";
+        latex += "\\int_{-\\pi}^{\\pi} \\sin(\\alpha x) \\sin^n(\\beta x) dx = \\textstyle{\\left \\{ \\begin{array}{cc} (-1)^{(n+1)/2} (-1)^m \\frac{2 \\pi}{2^n} \\binom{n}{m} & n \\mbox{ odd},\\ \\alpha = \\beta (2m-n) \\\\ 0 & \\mbox{otherwise} \\\\ \\end{array} \\right .}\\\\";
+        latex += "L = \\int_a^b \\sqrt{ \\left|\\sum_{i,j=1}^ng_{ij}(\\gamma(t))\\left(\\frac{d}{dt}x^i\\circ\\gamma(t)\\right)\\left(\\frac{d}{dt}x^j\\circ\\gamma(t)\\right)\\right|}\\,dt\\\\";
+        latex += "\\begin{array}{rl} s &= \\int_a^b\\left\\|\\frac{d}{dt}\\vec{r}\\,(u(t),v(t))\\right\\|\\,dt \\\\ &= \\int_a^b \\sqrt{u'(t)^2\\,\\vec{r}_u\\cdot\\vec{r}_u + 2u'(t)v'(t)\\, \\vec{r}_u\\cdot\\vec{r}_v+ v'(t)^2\\,\\vec{r}_v\\cdot\\vec{r}_v}\\,\\,\\, dt. \\end{array}\\\\";
+        latex += "\\end{array}";
+        return latex;
+    }
+
+}


### PR DESCRIPTION
as mentioned in #27, this will allow before and after comparisons of suggested performance improvements using jmh benchmarks.

* add jmh dependencies test scoped to pom.xml
* add profile for running jmh benchmarks to pom.xml
* add `Benchmarks.java` to benchmark parse and render of latex
* add Benchmarks section to README.md

The benchmarks are set up in the `jlatexmath` module so call:
```
cd jlatexmath
mvn clean install -P benchmark
```
The result for me on Xeon i7:

```
Result "org.scilab.forge.jlatexmath.Benchmarks.parseAndRenderLatex":
  569.302 ±(99.9%) 19.352 ops/s [Average]
  (min, avg, max) = (539.426, 569.302, 589.083), stdev = 12.800
  CI (99.9%): [549.950, 588.654] (assumes normal distribution)


# Run complete. Total time: 00:00:15

Benchmark                        Mode  Cnt    Score    Error  Units
Benchmarks.parseAndRenderLatex  thrpt   10  569.302 ± 19.352  ops/s
```