### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Regarding JLaTeXMath’s Classpath Exception and JavaScript: If you use the Goog
 
 ## Benchmarks
 To run jmh benchmarks (measuring parse and render performance):
-    # benchmarks are in core module
-    cd jlatexmath
-    mvn clean install -P benchmark
+
+```bash
+# benchmarks are in core module
+cd jlatexmath
+mvn clean install -P benchmark
+```

--- a/jlatexmath-example-giws/src/main/java/org/scilab/forge/example/giws/LaTeXGenerator.java
+++ b/jlatexmath-example-giws/src/main/java/org/scilab/forge/example/giws/LaTeXGenerator.java
@@ -50,8 +50,8 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 
-import javax.swing.JLabel;
 import javax.imageio.ImageIO;
+import javax.swing.JLabel;
 
 import org.scilab.forge.jlatexmath.TeXConstants;
 import org.scilab.forge.jlatexmath.TeXFormula;

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/JLaTeXMathElement.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/JLaTeXMathElement.java
@@ -50,16 +50,9 @@
 
 package org.scilab.forge.jlatexmath.fop;
 
-import org.scilab.forge.jlatexmath.TeXIcon;
-import org.scilab.forge.jlatexmath.TeXConstants;
-import org.scilab.forge.jlatexmath.TeXFormula;
-import org.scilab.forge.jlatexmath.SpaceAtom;
-
 import java.awt.Color;
 import java.awt.geom.Point2D;
 import java.util.HashMap;
-import java.util.List;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.StringTokenizer;
 
@@ -68,17 +61,13 @@ import org.apache.fop.apps.FOUserAgent;
 import org.apache.fop.datatypes.Length;
 import org.apache.fop.fo.FOEventHandler;
 import org.apache.fop.fo.FONode;
-import org.apache.fop.fo.XMLObj;
 import org.apache.fop.fo.PropertyList;
 import org.apache.fop.fo.properties.CommonFont;
 import org.apache.fop.fo.properties.FixedLength;
 import org.apache.fop.fo.properties.Property;
-import org.apache.fop.fo.properties.PercentLength;
-import org.apache.fop.datatypes.LengthBase;
-import org.apache.fop.fo.properties.LengthProperty;
-import org.apache.fop.fo.flow.BlockContainer;
-import org.apache.fop.fo.FONode;
-
+import org.scilab.forge.jlatexmath.TeXConstants;
+import org.scilab.forge.jlatexmath.TeXFormula;
+import org.scilab.forge.jlatexmath.TeXIcon;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/JLaTeXMathXMLHandler.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/JLaTeXMathXMLHandler.java
@@ -54,9 +54,7 @@ import org.apache.fop.render.Graphics2DAdapter;
 import org.apache.fop.render.Renderer;
 import org.apache.fop.render.RendererContext;
 import org.apache.fop.render.XMLHandler;
-
 import org.scilab.forge.jlatexmath.fop.image.loader.Graphics2DImagePainterJLaTeXMath;
-
 import org.w3c.dom.Document;
 
 /**

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/ImageJLaTeXMath.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/ImageJLaTeXMath.java
@@ -50,13 +50,11 @@
 
 package org.scilab.forge.jlatexmath.fop.image;
 
-import org.scilab.forge.jlatexmath.TeXIcon;
-import org.scilab.forge.jlatexmath.fop.JLaTeXMathObj;
-
-import org.apache.xmlgraphics.image.loader.Image;
 import org.apache.xmlgraphics.image.loader.ImageFlavor;
 import org.apache.xmlgraphics.image.loader.ImageInfo;
 import org.apache.xmlgraphics.image.loader.impl.AbstractImage;
+import org.scilab.forge.jlatexmath.TeXIcon;
+import org.scilab.forge.jlatexmath.fop.JLaTeXMathObj;
 
 /**
  * Image implementation

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/Graphics2DImagePainterJLaTeXMath.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/Graphics2DImagePainterJLaTeXMath.java
@@ -50,18 +50,16 @@
 
 package org.scilab.forge.jlatexmath.fop.image.loader;
 
-import org.scilab.forge.jlatexmath.TeXIcon;
-import org.scilab.forge.jlatexmath.fop.JLaTeXMathElement;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
 
 import org.apache.xmlgraphics.java2d.Graphics2DImagePainter;
+import org.scilab.forge.jlatexmath.TeXIcon;
+import org.scilab.forge.jlatexmath.fop.JLaTeXMathElement;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 /**
  * @author Calixte DENIZET

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/ImageConverterJLaTeXMathToG2D.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/ImageConverterJLaTeXMathToG2D.java
@@ -52,13 +52,12 @@ package org.scilab.forge.jlatexmath.fop.image.loader;
 
 import java.util.Map;
 
-import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
-
 import org.apache.xmlgraphics.image.loader.Image;
 import org.apache.xmlgraphics.image.loader.ImageException;
 import org.apache.xmlgraphics.image.loader.ImageFlavor;
 import org.apache.xmlgraphics.image.loader.impl.AbstractImageConverter;
 import org.apache.xmlgraphics.image.loader.impl.ImageGraphics2D;
+import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
 
 /**
  * Convert a LaTeX label to a Graphics2d Painter.

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/ImageLoaderFactoryJLaTeXMath.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/ImageLoaderFactoryJLaTeXMath.java
@@ -50,12 +50,11 @@
 
 package org.scilab.forge.jlatexmath.fop.image.loader;
 
-import org.scilab.forge.jlatexmath.fop.JLaTeXMathObj;
-import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
-
 import org.apache.xmlgraphics.image.loader.ImageFlavor;
 import org.apache.xmlgraphics.image.loader.impl.AbstractImageLoaderFactory;
 import org.apache.xmlgraphics.image.loader.spi.ImageLoader;
+import org.scilab.forge.jlatexmath.fop.JLaTeXMathObj;
+import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
 
 /**
  * @author Calixte DENIZET

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/ImageLoaderJLaTeXMath.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/ImageLoaderJLaTeXMath.java
@@ -53,17 +53,14 @@ package org.scilab.forge.jlatexmath.fop.image.loader;
 import java.io.IOException;
 import java.util.Map;
 
-import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
-
 import org.apache.xmlgraphics.image.loader.Image;
 import org.apache.xmlgraphics.image.loader.ImageException;
 import org.apache.xmlgraphics.image.loader.ImageFlavor;
 import org.apache.xmlgraphics.image.loader.ImageInfo;
 import org.apache.xmlgraphics.image.loader.ImageSessionContext;
 import org.apache.xmlgraphics.image.loader.impl.AbstractImageLoader;
-import org.apache.xmlgraphics.image.loader.impl.ImageXMLDOM;
-
 import org.scilab.forge.jlatexmath.fop.JLaTeXMathObj;
+import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
 
 public class ImageLoaderJLaTeXMath extends AbstractImageLoader {
 

--- a/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/PreloaderJLaTeXMath.java
+++ b/jlatexmath-fop/src/main/java/org/scilab/forge/jlatexmath/fop/image/loader/PreloaderJLaTeXMath.java
@@ -55,18 +55,16 @@ import java.awt.Color;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
-import org.scilab.forge.jlatexmath.TeXIcon;
-import org.scilab.forge.jlatexmath.fop.JLaTeXMathObj;
-import org.scilab.forge.jlatexmath.fop.JLaTeXMathElement;
-import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
-
 import org.apache.xmlgraphics.image.loader.ImageContext;
 import org.apache.xmlgraphics.image.loader.ImageInfo;
 import org.apache.xmlgraphics.image.loader.ImageSize;
 import org.apache.xmlgraphics.image.loader.impl.AbstractImagePreloader;
+import org.scilab.forge.jlatexmath.TeXIcon;
+import org.scilab.forge.jlatexmath.fop.JLaTeXMathElement;
+import org.scilab.forge.jlatexmath.fop.JLaTeXMathObj;
+import org.scilab.forge.jlatexmath.fop.image.ImageJLaTeXMath;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 /**
  * Preloader

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/AlphabetRegistration.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/AlphabetRegistration.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.lang.Character.UnicodeBlock;
-
 public interface AlphabetRegistration {
     
     public static final Character.UnicodeBlock[] JLM_GREEK = new Character.UnicodeBlock[]{Character.UnicodeBlock.GREEK, Character.UnicodeBlock.GREEK_EXTENDED};

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/AlphabetRegistrationException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/AlphabetRegistrationException.java
@@ -50,6 +50,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class AlphabetRegistrationException extends Exception {
     
+    private static final long serialVersionUID = 2024902825275906423L;
+
     protected AlphabetRegistrationException(String str) {
         super(str);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ArrayOfAtoms.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ArrayOfAtoms.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.BitSet;
-import java.util.Map;
 import java.util.LinkedList;
 
 public class ArrayOfAtoms extends TeXFormula {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/Box.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/Box.java
@@ -48,13 +48,12 @@
 
 package org.scilab.forge.jlatexmath;
 
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
-import java.awt.geom.Rectangle2D;
 import java.awt.Stroke;
-import java.awt.BasicStroke;
+import java.awt.geom.Rectangle2D;
 import java.util.LinkedList;
-import java.util.List;
 
 /**
  * An abstract graphical representation of a formula, that can be painted. All characters, font

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/CharBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/CharBox.java
@@ -49,9 +49,6 @@ package org.scilab.forge.jlatexmath;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
-import java.awt.geom.Rectangle2D;
-import java.awt.Stroke;
-import java.awt.BasicStroke;
 
 /**
  * A box representing a single character.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFont.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFont.java
@@ -47,14 +47,13 @@
 package org.scilab.forge.jlatexmath;
 
 import java.awt.Font;
-import java.util.Map;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
-import java.lang.Character.UnicodeBlock;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.io.FileNotFoundException;
+import java.util.Map;
 
 /**
  * The default implementation of the TeXFont-interface. All font information is read

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFont.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFont.java
@@ -73,11 +73,6 @@ public class DefaultTeXFont implements TeXFont {
     protected final static int SMALL = 2;
     protected final static int UNICODE = 3;
 
-    /**
-     * Number of font ids in a single font description file.
-     */
-    private static final int NUMBER_OF_FONT_IDS = 256;
-
     private static Map<String, CharFont[]> textStyleMappings;
     private static Map<String, CharFont> symbolMappings;
     private static FontInfo[] fontInfo = new FontInfo[0];

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFontParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFontParser.java
@@ -48,25 +48,23 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.lang.reflect.Method;
-
 import java.awt.Font;
+import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.awt.GraphicsEnvironment;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.NamedNodeMap;
+
 import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 
 /**

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DelimiterMappingNotFoundException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DelimiterMappingNotFoundException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class DelimiterMappingNotFoundException extends JMathTeXException {
 
+    private static final long serialVersionUID = 273456491396361682L;
+
     protected DelimiterMappingNotFoundException(char delimiter) {
 	super("No mapping found for the character '" + delimiter + "'! "
 	      + "Insert a <" + TeXFormulaSettingsParser.CHARTODEL_MAPPING_EL

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DoubleFramedAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DoubleFramedAtom.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.awt.Color;
-
 /**
  * An atom representing a boxed base atom. 
  */

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/EmptyFormulaException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/EmptyFormulaException.java
@@ -48,6 +48,8 @@ package org.scilab.forge.jlatexmath;
 
 public class EmptyFormulaException extends Exception {
 
+    private static final long serialVersionUID = -8034123603703695067L;
+
     public EmptyFormulaException() {
 	super("Illegal operation with an empty Formula!");
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FcscoreBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FcscoreBox.java
@@ -45,9 +45,9 @@
 
 package org.scilab.forge.jlatexmath;
 
+import java.awt.BasicStroke;
 import java.awt.Graphics2D;
 import java.awt.Stroke;
-import java.awt.BasicStroke;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FencedAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FencedAtom.java
@@ -80,7 +80,7 @@ public class FencedAtom extends Atom {
         this(base, l, null, r);
     }
 
-    public FencedAtom(Atom base, SymbolAtom l, List m, SymbolAtom r) {
+    public FencedAtom(Atom base, SymbolAtom l, List<MiddleAtom> m, SymbolAtom r) {
         if (base == null)
             this.base = new RowAtom(); // empty base
         else

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FontAlreadyLoadedException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FontAlreadyLoadedException.java
@@ -48,6 +48,8 @@ package org.scilab.forge.jlatexmath;
 
 public class FontAlreadyLoadedException extends XMLResourceParseException {
 
+    private static final long serialVersionUID = -6172324828113185078L;
+
     public FontAlreadyLoadedException(String msg) {
         super(msg);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FormulaNotFoundException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FormulaNotFoundException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class FormulaNotFoundException extends JMathTeXException {
 
+    private static final long serialVersionUID = 7660105446051204466L;
+
     protected FormulaNotFoundException(String name) {
 	super("There's no predefined TeXFormula with the name '" + name
 	      + "' defined in '" + PredefinedTeXFormulaParser.RESOURCE_NAME

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FramedBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FramedBox.java
@@ -45,11 +45,11 @@
 
 package org.scilab.forge.jlatexmath;
 
+import java.awt.BasicStroke;
+import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Stroke;
-import java.awt.BasicStroke;
 import java.awt.geom.Rectangle2D;
-import java.awt.Color;
 
 /**
  * A box representing a rotated box.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GeoGebraLogoBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GeoGebraLogoBox.java
@@ -60,7 +60,6 @@ public class GeoGebraLogoBox extends Box {
     private static final Color blue = new Color(153, 153, 255);
 
     private static final BasicStroke st = new BasicStroke(3.79999995f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 4f);
-    private static final BasicStroke stC = new BasicStroke(1f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 4f);
 
     public GeoGebraLogoBox(float w, float h) {
 	this.depth = 0;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GeoGebraLogoBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GeoGebraLogoBox.java
@@ -45,12 +45,11 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.awt.Graphics2D;
-import java.awt.Color;
 import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.Stroke;
 import java.awt.geom.AffineTransform;
-import java.awt.image.BufferedImage;
 
 /**
  * A box representing a box containing a graphics.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GlueSettingsParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GlueSettingsParser.java
@@ -46,13 +46,13 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GraphicsAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GraphicsAtom.java
@@ -45,16 +45,15 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.awt.image.ImageObserver;
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.awt.MediaTracker;
-import java.awt.Label;
 import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Label;
+import java.awt.MediaTracker;
 import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
 import java.io.File;
-import java.net.URL;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 
 /**

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GraphicsBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/GraphicsBox.java
@@ -46,9 +46,9 @@
 package org.scilab.forge.jlatexmath;
 
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import java.awt.RenderingHints;
 
 /**
  * A box representing a box containing a graphics.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/HorizontalBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/HorizontalBox.java
@@ -49,7 +49,6 @@ package org.scilab.forge.jlatexmath;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/HorizontalBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/HorizontalBox.java
@@ -144,7 +144,7 @@ public class HorizontalBox extends Box {
         // iterate from the last child box to the first untill a font id is found
         // that's not equal to NO_FONT
         int fontId = TeXFont.NO_FONT;
-        for (ListIterator it = children.listIterator(children.size()); fontId == TeXFont.NO_FONT && it.hasPrevious();)
+        for (ListIterator<Box> it = children.listIterator(children.size()); fontId == TeXFont.NO_FONT && it.hasPrevious();)
             fontId = ((Box) it.previous()).getLastFontId();
 
         return fontId;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/HorizontalRule.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/HorizontalRule.java
@@ -46,9 +46,9 @@
 
 package org.scilab.forge.jlatexmath;
 
+import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
-import java.awt.Color;
 
 /**
  * A box representing a horizontal line.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidAtomTypeException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidAtomTypeException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class InvalidAtomTypeException extends JMathTeXException {
 
+    private static final long serialVersionUID = -6558639348158242539L;
+
     protected InvalidAtomTypeException(String msg) {
 	super(msg);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidDelimiterException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidDelimiterException.java
@@ -54,7 +54,9 @@ package org.scilab.forge.jlatexmath;
  */
 public class InvalidDelimiterException extends JMathTeXException {
 
-   protected InvalidDelimiterException(String symbolName) {
+    private static final long serialVersionUID = 212553180078002724L;
+
+protected InvalidDelimiterException(String symbolName) {
       super("The symbol with the name '" + symbolName
             + "' is not defined as a delimiter ("
             + TeXSymbolParser.DELIMITER_ATTR + "='true') in '"

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidDelimiterTypeException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidDelimiterTypeException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class InvalidDelimiterTypeException extends JMathTeXException {
 
+    private static final long serialVersionUID = -7170484583239756156L;
+
     protected InvalidDelimiterTypeException() {
 	super(
 	      "The delimiter type was not valid! "

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidMatrixException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidMatrixException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class InvalidMatrixException extends JMathTeXException {
 
+   private static final long serialVersionUID = -6766435055092128073L;
+
    protected InvalidMatrixException(String msg) {
       super(msg);
    }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidSymbolTypeException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidSymbolTypeException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class InvalidSymbolTypeException extends JMathTeXException {
 
+    private static final long serialVersionUID = 6679471054726869590L;
+
     protected InvalidSymbolTypeException(String msg) {
 	super(msg);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidTeXFormulaException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidTeXFormulaException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class InvalidTeXFormulaException extends JMathTeXException {
 
+    private static final long serialVersionUID = -1360488533073280569L;
+
     protected InvalidTeXFormulaException(String msg) {
 	super(msg);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidUnitException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/InvalidUnitException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class InvalidUnitException extends JMathTeXException {
 
+    private static final long serialVersionUID = 860909774647515072L;
+
     protected InvalidUnitException() {
 	super("The delimiter type was not valid! "
 	      + "Use one of the unit constants from the class 'TeXConstants'.");

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/JMathTeXException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/JMathTeXException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class JMathTeXException extends RuntimeException {
 
+    private static final long serialVersionUID = 6788678896908035811L;
+
     protected JMathTeXException(String msg) {
 	super(msg);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/JavaFontRenderingBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/JavaFontRenderingBox.java
@@ -51,7 +51,6 @@ import java.awt.font.TextAttribute;
 import java.awt.font.TextLayout;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.lang.reflect.Field;
 import java.util.Hashtable;
 import java.util.Map;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/JavaFontRenderingBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/JavaFontRenderingBox.java
@@ -63,7 +63,6 @@ public class JavaFontRenderingBox extends Box {
 
     private static Font font = new Font("Serif", Font.PLAIN, 10);
 
-    private String str;
     private TextLayout text;
     private float size;
     private static TextAttribute KERNING;
@@ -81,7 +80,6 @@ public class JavaFontRenderingBox extends Box {
     }
 
     public JavaFontRenderingBox(String str, int type, float size, Font f, boolean kerning) {
-        this.str = str;
         this.size = size;
 
         if (kerning && KERNING != null) {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MacroInfo.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MacroInfo.java
@@ -84,7 +84,7 @@ public class MacroInfo {
     
     public MacroInfo(String className, String methodName, float nbArgs) {
 	int nba = (int) nbArgs;
-	Class[] args = new Class[]{TeXParser.class, String[].class};
+	Class<?>[] args = new Class<?>[]{TeXParser.class, String[].class};
 	
 	try {
 	    Object pack = Packages.get(className);
@@ -104,7 +104,7 @@ public class MacroInfo {
 
     public MacroInfo(String className, String methodName, float nbArgs, float posOpts) {
 	int nba = (int) nbArgs;
-	Class[] args = new Class[]{TeXParser.class, String[].class};
+	Class<?>[] args = new Class<?>[]{TeXParser.class, String[].class};
 
 	try {
 	    Object pack = Packages.get(className);

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MacroInfo.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MacroInfo.java
@@ -45,8 +45,8 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 
 public class MacroInfo {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MatrixAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MatrixAtom.java
@@ -45,11 +45,10 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.BitSet;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A box representing a matrix.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MatrixAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/MatrixAtom.java
@@ -75,9 +75,6 @@ public class MatrixAtom extends Atom {
     private ArrayOfAtoms matrix;
     private int[] position;
     private Map<Integer, VlineAtom> vlines = new HashMap<Integer, VlineAtom>();
-    private boolean isAlign;
-    private boolean isAlignat;
-    private boolean isFl;
     private int type;
     private boolean isPartial;
     private boolean spaceAround;
@@ -244,7 +241,6 @@ public class MatrixAtom extends Atom {
     }
 
     public Box[] getColumnSep(TeXEnvironment env, float width) {
-        int row = matrix.row;
         int col = matrix.col;
         Box[] arr = new Box[col + 1];
         Box Align, AlignSep, Hsep;
@@ -444,7 +440,6 @@ public class MatrixAtom extends Atom {
         VerticalBox vb = new VerticalBox();
         Box Vsep = vsep_in.createBox(env);
         vb.add(vsep_ext_top.createBox(env));
-        float vsepH = Vsep.getHeight();
         float totalHeight = 0;
 
         for (int i = 0; i < row; i++) {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/NewEnvironmentMacro.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/NewEnvironmentMacro.java
@@ -45,9 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.HashMap;
-import java.util.regex.Matcher;
-
 public class NewEnvironmentMacro extends NewCommandMacro {
     
     public NewEnvironmentMacro() {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OgonekAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OgonekAtom.java
@@ -50,7 +50,6 @@ package org.scilab.forge.jlatexmath;
  */
 public class OgonekAtom extends Atom {
     
-    private static final SymbolAtom ogonek = SymbolAtom.get("ogonek");
     private Atom base;
 
     public OgonekAtom(Atom base) {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OvalAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OvalAtom.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.awt.Color;
-
 /**
  * An atom representing a boxed base atom. 
  */

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OvalBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OvalBox.java
@@ -45,9 +45,9 @@
 
 package org.scilab.forge.jlatexmath;
 
+import java.awt.BasicStroke;
 import java.awt.Graphics2D;
 import java.awt.Stroke;
-import java.awt.BasicStroke;
 import java.awt.geom.RoundRectangle2D;
 
 /**

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OvalBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/OvalBox.java
@@ -55,8 +55,6 @@ import java.awt.geom.RoundRectangle2D;
  */
 public class OvalBox extends FramedBox {
     
-    private float shadowRule;
-
     public OvalBox(FramedBox fbox) {
 	super(fbox.box, fbox.thickness, fbox.space);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ParseException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ParseException.java
@@ -51,6 +51,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class ParseException extends JMathTeXException {
     
+    private static final long serialVersionUID = -3498558910250213782L;
+
     public ParseException(String str, Throwable cause) {
         super(str, cause);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/PredefMacroInfo.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/PredefMacroInfo.java
@@ -45,10 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-
 /**
  * Class to load the predefined commands. Mainly wrote to avoid the use of the Java reflection.
  */

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/PredefinedTeXFormulaParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/PredefinedTeXFormulaParser.java
@@ -46,10 +46,11 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.Map;
 import java.io.InputStream;
+import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/PredefinedTeXFormulaParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/PredefinedTeXFormulaParser.java
@@ -59,8 +59,6 @@ import org.w3c.dom.NodeList;
  */
 public class PredefinedTeXFormulaParser {
     
-    private static final String RESOURCE_DIR = "";
-    
     public static final String RESOURCE_NAME = "PredefinedTeXFormulas.xml";
     
     private Element root;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ResourceParseException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ResourceParseException.java
@@ -51,6 +51,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class ResourceParseException extends JMathTeXException {
     
+    private static final long serialVersionUID = -7083164592631533649L;
+
     protected ResourceParseException(String msg) {
         super(msg);
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/RotateBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/RotateBox.java
@@ -69,7 +69,6 @@ public class RotateBox extends Box {
     protected double angle = 0;
     private Box box;
     private float xmax, xmin, ymax, ymin;
-    private int option;
 
     private float shiftX;
     private float shiftY;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/RowAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/RowAtom.java
@@ -50,7 +50,6 @@ package org.scilab.forge.jlatexmath;
 
 import java.util.BitSet;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.ListIterator;
 
 import org.scilab.forge.jlatexmath.dynamic.DynamicAtom;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/RuleAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/RuleAtom.java
@@ -52,7 +52,6 @@ public class RuleAtom extends Atom {
     
     private int wunit, hunit, runit;
     private float w, h, r;
-    private SpaceAtom width, height, raise;
  
     public RuleAtom(int wunit, float width, int hunit, float height, int runit, float raise) {
 	this.wunit = wunit;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ScaleBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ScaleBox.java
@@ -54,7 +54,6 @@ public class ScaleBox extends Box {
 
     private Box box;
     private double xscl, yscl;
-    private float factor = 1;
 
     public ScaleBox(Box b, double xscl, double yscl) {
 	this.box = b;
@@ -68,7 +67,6 @@ public class ScaleBox extends Box {
 
     public ScaleBox(Box b, float factor) {
 	this(b, (double) factor, (double) factor);
-	this.factor = factor;
     }
     
     public void draw(Graphics2D g2, float x, float y) {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ShadowAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ShadowAtom.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.awt.Color;
-
 /**
  * An atom representing a boxed base atom. 
  */

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ShadowBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/ShadowBox.java
@@ -45,9 +45,9 @@
 
 package org.scilab.forge.jlatexmath;
 
+import java.awt.BasicStroke;
 import java.awt.Graphics2D;
 import java.awt.Stroke;
-import java.awt.BasicStroke;
 import java.awt.geom.Rectangle2D;
 
 /**

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/SymbolAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/SymbolAtom.java
@@ -48,11 +48,11 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.BitSet;
-import java.util.Map;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.util.BitSet;
+import java.util.Map;
 
 /**
  * A box representing a symbol (a non-alphanumeric character).

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/SymbolMappingNotFoundException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/SymbolMappingNotFoundException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class SymbolMappingNotFoundException extends JMathTeXException {
 
+    private static final long serialVersionUID = 2659192520874275262L;
+
     protected SymbolMappingNotFoundException(String symbolName) {
 	super("No mapping found for the symbol '" + symbolName + "'! "
 	      + "Insert a <" + DefaultTeXFontParser.SYMBOL_MAPPING_EL

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/SymbolNotFoundException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/SymbolNotFoundException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class SymbolNotFoundException extends JMathTeXException {
 
+    private static final long serialVersionUID = -3005021333407670912L;
+
     protected SymbolNotFoundException(String name) {
 	super("There's no symbol with the name '" + name + "' defined in '"
 	      + TeXSymbolParser.RESOURCE_NAME + "'!");

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
@@ -48,30 +48,25 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.List;
-import java.util.LinkedList;
-import java.util.Set;
-import java.util.Stack;
-import java.io.InputStream;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Graphics2D;
-import java.awt.Insets;
-import java.awt.image.BufferedImage;
-import java.awt.GraphicsEnvironment;
-import java.awt.Image;
-import java.awt.Toolkit;
 import javax.imageio.ImageIO;
 import javax.imageio.stream.FileImageOutputStream;
-import java.lang.Character.UnicodeBlock;
 
 /**
  * Represents a logical mathematical formula that will be displayed (by creating a

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
@@ -102,28 +102,8 @@ public class TeXFormula {
     public static final int ROMAN = 8;
     public static final int TYPEWRITER = 16;
 
-    // table for putting delimiters over and under formula's,
-    // indexed by constants from "TeXConstants"
-    private static final String[][] delimiterNames = {
-        { "lbrace", "rbrace" },
-        { "lsqbrack", "rsqbrack" },
-        { "lbrack", "rbrack" },
-        { "downarrow", "downarrow" },
-        { "uparrow", "uparrow" },
-        { "updownarrow", "updownarrow" },
-        { "Downarrow", "Downarrow" },
-        { "Uparrow", "Uparrow" },
-        { "Updownarrow", "Updownarrow" },
-        { "vert", "vert" },
-        { "Vert", "Vert" }
-    };
-
     // point-to-pixel conversion
     public static float PIXELS_PER_POINT = 1f;
-
-    // used as second index in "delimiterNames" table (over or under)
-    private static final int OVER_DEL = 0;
-    private static final int UNDER_DEL = 1;
 
     // for comparing floats with 0
     protected static final float PREC = 0.0000001f;
@@ -248,7 +228,6 @@ public class TeXFormula {
      */
     public TeXFormula(String s, Map<String, String> map) throws ParseException {
         this.jlmXMLMap = map;
-        this.textStyle = textStyle;
         parser = new TeXParser(s, this);
         parser.parse();
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormulaParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormulaParser.java
@@ -49,11 +49,10 @@ package org.scilab.forge.jlatexmath;
 import java.awt.Color;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
 
 import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * Parses a "TeXFormula"-element representing a predefined TeXFormula's from an XML-file.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormulaParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormulaParser.java
@@ -90,7 +90,7 @@ public class TeXFormulaParser {
                 // parse arguments
                 NodeList args = el.getElementsByTagName("Argument");
                 // get argument classes and values
-                Class[] argClasses = getArgumentClasses(args);
+                Class<?>[] argClasses = getArgumentClasses(args);
                 Object[] argValues = getArgumentValues(args);
                 // invoke method
                 try {
@@ -118,7 +118,7 @@ public class TeXFormulaParser {
             // parse arguments
             NodeList args = el.getElementsByTagName("Argument");
             // get argument classes and values
-            Class[] argClasses = getArgumentClasses(args);
+            Class<?>[] argClasses = getArgumentClasses(args);
             Object[] argValues = getArgumentValues(args);
             // create TeXFormula object
 	    //String code = "TeXFormula.predefinedTeXFormulasAsString.put(\"%s\", \"%s\");";
@@ -148,7 +148,7 @@ public class TeXFormulaParser {
             // parse arguments
             NodeList args = el.getElementsByTagName("Argument");
             // get argument classes and values
-            Class[] argClasses = getArgumentClasses(args);
+            Class<?>[] argClasses = getArgumentClasses(args);
             Object[] argValues = getArgumentValues(args);
             // create TeXFormula object
             try {
@@ -158,7 +158,7 @@ public class TeXFormulaParser {
             } catch (IllegalArgumentException e) {
 		String err = "IllegalArgumentException:\n";
 		err += "ClassLoader to load this class (TeXFormulaParser): " + this.getClass().getClassLoader() + "\n";
-		for (Class cl : argClasses) {
+		for (Class<?> cl : argClasses) {
 		    err += "Created class: " + cl + " loaded with the ClassLoader: " + cl.getClassLoader() + "\n";
 		}
 		for (Object obj : argValues) {
@@ -454,9 +454,9 @@ public class TeXFormulaParser {
         return res;
     }
 
-    private static Class[] getArgumentClasses(NodeList args)
+    private static Class<?>[] getArgumentClasses(NodeList args)
         throws ResourceParseException {
-        Class[] res = new Class[args.getLength()];
+        Class<?>[] res = new Class<?>[args.getLength()];
         int i = 0;
         for (int j = 0; j < args.getLength(); j++) {
             Element arg = (Element)args.item(j);
@@ -469,7 +469,7 @@ public class TeXFormulaParser {
                     PredefinedTeXFormulaParser.RESOURCE_NAME, "Argument", "type",
                     "has an invalid class name value!");
             } else {
-                res[i] = (Class) cl;
+                res[i] = (Class<?>) cl;
             }
             i++;
         }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormulaSettingsParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormulaSettingsParser.java
@@ -46,12 +46,10 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.io.InputStream;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXParser.java
@@ -68,7 +68,6 @@ public class TeXParser {
     private boolean arrayMode;
     private boolean ignoreWhiteSpace = true;
     private boolean isPartial;
-    private boolean autoNumberBreaking;
 
     // the escape character
     private static final char ESCAPE = '\\';
@@ -83,10 +82,6 @@ public class TeXParser {
 
     // Percent char for comments
     private static final char PERCENT = '%';
-
-    // used as second index in "delimiterNames" table (over or under)
-    private static final int OVER_DEL = 0;
-    private static final int UNDER_DEL = 1;
 
     // script characters (for parsing)
     private static final char SUB_SCRIPT = '_';
@@ -1090,7 +1085,7 @@ public class TeXParser {
         if (pos == len)
             return null;
 
-        int ogroup = 1, spos;
+        int spos;
         char ch = '\0';
 
         skipWhiteSpace();

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXParser.java
@@ -46,8 +46,6 @@
 package org.scilab.forge.jlatexmath;
 
 import java.awt.Color;
-import java.awt.Font;
-import java.lang.Character.UnicodeBlock;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXSymbolParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXSymbolParser.java
@@ -46,11 +46,12 @@
 
 package org.scilab.forge.jlatexmath;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.io.InputStream;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TextStyleMappingNotFoundException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TextStyleMappingNotFoundException.java
@@ -53,6 +53,8 @@ package org.scilab.forge.jlatexmath;
  */
 public class TextStyleMappingNotFoundException extends JMathTeXException {
     
+    private static final long serialVersionUID = 4887043712790844966L;
+
     protected TextStyleMappingNotFoundException(String styleName) {
 	super("No mapping found for the text style '" + styleName + "'! "
 	      + "Insert a <" + DefaultTeXFontParser.STYLE_MAPPING_EL

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/URLAlphabetRegistration.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/URLAlphabetRegistration.java
@@ -45,10 +45,8 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.lang.Character.UnicodeBlock;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.lang.ClassLoader;
 
 public class URLAlphabetRegistration implements AlphabetRegistration {
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/UnderOverArrowAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/UnderOverArrowAtom.java
@@ -51,12 +51,10 @@ package org.scilab.forge.jlatexmath;
 public class UnderOverArrowAtom extends Atom {
 
     private Atom base;
-    private String arrow;
     private boolean over, left = false, dble = false;
 
     public UnderOverArrowAtom(Atom base, boolean left, boolean over) {
         this.base = base;
-	this.arrow = left ? "leftarrow" : "rightarrow";
 	this.left = left;
 	this.over = over;
     }
@@ -68,8 +66,6 @@ public class UnderOverArrowAtom extends Atom {
     }
 
     public Box createBox(TeXEnvironment env) {
-	TeXFont tf = env.getTeXFont();
-        int style = env.getStyle();
 	Box b = base != null ? base.createBox(env) : new StrutBox(0, 0, 0, 0);
 	float sep = new SpaceAtom(TeXConstants.UNIT_POINT, 1f, 0, 0).createBox(env).getWidth();
 	Box arrow;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/VRowAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/VRowAtom.java
@@ -48,9 +48,7 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.util.BitSet;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.ListIterator;
 
 /**

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/VRowAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/VRowAtom.java
@@ -124,8 +124,8 @@ public class VRowAtom extends Atom {
         if (halign != TeXConstants.ALIGN_NONE) {
             float maxWidth = -Float.POSITIVE_INFINITY;
             LinkedList<Box> boxes = new LinkedList<>();
-            for (ListIterator it = elements.listIterator(); it.hasNext();) {
-                Box b = ((Atom)it.next()).createBox(env);
+            for (ListIterator<Atom> it = elements.listIterator(); it.hasNext();) {
+                Box b = it.next().createBox(env);
                 boxes.add(b);
                 if (maxWidth < b.getWidth()) {
                     maxWidth = b.getWidth();
@@ -134,8 +134,8 @@ public class VRowAtom extends Atom {
             Box interline = new StrutBox(0, env.getInterline(), 0, 0);
 
             // convert atoms to boxes and add to the horizontal box
-            for (ListIterator it = boxes.listIterator(); it.hasNext();) {
-                Box b = (Box) it.next();
+            for (ListIterator<Box> it = boxes.listIterator(); it.hasNext();) {
+                Box b = it.next();
                 vb.add(new HorizontalBox(b, maxWidth, halign));
                 if (addInterline && it.hasNext()) {
                     vb.add(interline);
@@ -145,8 +145,8 @@ public class VRowAtom extends Atom {
             Box interline = new StrutBox(0, env.getInterline(), 0, 0);
 
             // convert atoms to boxes and add to the horizontal box
-            for (ListIterator it = elements.listIterator(); it.hasNext();) {
-                vb.add(((Atom)it.next()).createBox(env));
+            for (ListIterator<Atom> it = elements.listIterator(); it.hasNext();) {
+                vb.add(it.next().createBox(env));
                 if (addInterline && it.hasNext()) {
                     vb.add(interline);
                 }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/VerticalBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/VerticalBox.java
@@ -127,9 +127,9 @@ class VerticalBox extends Box {
         // iterate from the last child box (the lowest) to the first (the highest)
         // untill a font id is found that's not equal to NO_FONT
         int fontId = TeXFont.NO_FONT;
-        for (ListIterator it = children.listIterator(children.size()); fontId == TeXFont.NO_FONT
+        for (ListIterator<Box> it = children.listIterator(children.size()); fontId == TeXFont.NO_FONT
                  && it.hasPrevious();)
-            fontId = ((Box) it.previous()).getLastFontId();
+            fontId = it.previous().getLastFontId();
 
         return fontId;
     }

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/WebStartAlphabetRegistration.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/WebStartAlphabetRegistration.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.lang.Character.UnicodeBlock;
-
 import org.scilab.forge.jlatexmath.cyrillic.CyrillicRegistration;
 import org.scilab.forge.jlatexmath.greek.GreekRegistration;
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XArrowAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XArrowAtom.java
@@ -60,8 +60,6 @@ public class XArrowAtom extends Atom {
     } 
 
     public Box createBox(TeXEnvironment env) {
-	TeXFont tf = env.getTeXFont();
-        int style = env.getStyle();
 	Box O = over != null ? over.createBox(env.supStyle()) : new StrutBox(0, 0, 0, 0);
 	Box U = under != null ? under.createBox(env.subStyle()) : new StrutBox(0, 0, 0, 0);
 	Box oside = new SpaceAtom(TeXConstants.UNIT_EM, 1.5f, 0, 0).createBox(env.supStyle());

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XLeftRightArrowFactory.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XLeftRightArrowFactory.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath;
 
-import java.awt.Color;
-
 /**
  * Responsible for creating a box containing a delimiter symbol that exists
  * in different sizes.

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XLeftRightArrowFactory.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XLeftRightArrowFactory.java
@@ -56,8 +56,6 @@ public class XLeftRightArrowFactory {
     private static final Atom RIGHT = SymbolAtom.get("rightarrow");
     
     public static Box create(boolean left, TeXEnvironment env, float width) {
-        TeXFont tf = env.getTeXFont();
-        int style = env.getStyle();
 	Box arr = left ? LEFT.createBox(env) : RIGHT.createBox(env);
 	float h = arr.getHeight();
 	float d = arr.getDepth();
@@ -99,8 +97,6 @@ public class XLeftRightArrowFactory {
     }
     
     public static Box create(TeXEnvironment env, float width) {
-        TeXFont tf = env.getTeXFont();
-        int style = env.getStyle();
 	Box left = LEFT.createBox(env);
 	Box right = RIGHT.createBox(env);
 	float swidth = left.getWidth() + right.getWidth();

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XMLResourceParseException.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/XMLResourceParseException.java
@@ -48,6 +48,8 @@ package org.scilab.forge.jlatexmath;
 
 public class XMLResourceParseException extends ResourceParseException {
 
+    private static final long serialVersionUID = 2091302779298293946L;
+
     /*
      * Attribute problem
      */

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/cache/JLaTeXMathCache.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/cache/JLaTeXMathCache.java
@@ -71,7 +71,7 @@ public final class JLaTeXMathCache {
     private static final AffineTransform identity = new AffineTransform();
     private static ConcurrentMap<CachedTeXFormula, SoftReference<CachedImage>> cache = new ConcurrentHashMap<CachedTeXFormula, SoftReference<CachedImage>>(128);
     private static int max = Integer.MAX_VALUE;
-    private static ReferenceQueue queue = new ReferenceQueue();
+    private static ReferenceQueue<CachedImage> queue = new ReferenceQueue<CachedImage>();
 
     private JLaTeXMathCache() { }
 
@@ -253,7 +253,7 @@ public final class JLaTeXMathCache {
         SoftReference<CachedImage> img = new SoftReference<CachedImage>(new CachedImage(image, cached), queue);
 
         if (cache.size() >= max) {
-            Reference soft;
+            Reference<? extends CachedImage> soft;
             while ((soft = queue.poll()) != null) {
                 CachedImage ci = (CachedImage) soft.get();
                 if (ci != null) {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/cache/JLaTeXMathCache.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/cache/JLaTeXMathCache.java
@@ -51,12 +51,12 @@ import java.awt.Image;
 import java.awt.Insets;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import java.lang.ref.ReferenceQueue;
 import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.scilab.forge.jlatexmath.ParseException;
 import org.scilab.forge.jlatexmath.TeXFormula;

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/cyrillic/CyrillicRegistration.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/cyrillic/CyrillicRegistration.java
@@ -45,8 +45,6 @@
 
 package org.scilab.forge.jlatexmath.cyrillic;
 
-import java.lang.Character.UnicodeBlock;
-
 import org.scilab.forge.jlatexmath.AlphabetRegistration;
 
 public class CyrillicRegistration implements AlphabetRegistration {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/greek/GreekRegistration.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/greek/GreekRegistration.java
@@ -28,8 +28,6 @@
 
 package org.scilab.forge.jlatexmath.greek;
 
-import java.lang.Character.UnicodeBlock;
-
 import org.scilab.forge.jlatexmath.AlphabetRegistration;
 
 public class GreekRegistration implements AlphabetRegistration {

--- a/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/basic/Example2.java
+++ b/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/basic/Example2.java
@@ -44,8 +44,6 @@
  */
 package org.scilab.forge.jlatexmath.examples.basic;
 
-import java.io.IOException;
-
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Insets;

--- a/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/basic/Example5.java
+++ b/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/basic/Example5.java
@@ -44,7 +44,6 @@
  */
 package org.scilab.forge.jlatexmath.examples.basic;
 
-import java.io.IOException;
 import java.awt.Color;
 
 import org.scilab.forge.jlatexmath.TeXConstants;

--- a/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/basic/ExampleSwing2.java
+++ b/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/basic/ExampleSwing2.java
@@ -4,6 +4,7 @@ import java.awt.Dimension;
 import javax.swing.BorderFactory;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+
 import org.scilab.forge.jlatexmath.TeXConstants;
 import org.scilab.forge.jlatexmath.TeXFormula;
 import org.scilab.forge.jlatexmath.TeXIcon;

--- a/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/macros/FooPackage.java
+++ b/jlatexmath/src/test/java/org/scilab/forge/jlatexmath/examples/macros/FooPackage.java
@@ -45,18 +45,18 @@
 
 package org.scilab.forge.jlatexmath.examples.macros; 
 
-import org.scilab.forge.jlatexmath.Atom;
-import org.scilab.forge.jlatexmath.TeXParser;
-import org.scilab.forge.jlatexmath.ParseException;
-import org.scilab.forge.jlatexmath.TeXFormula;
-import org.scilab.forge.jlatexmath.TeXEnvironment;
-import org.scilab.forge.jlatexmath.TeXConstants;
-import org.scilab.forge.jlatexmath.SpaceAtom;
-import org.scilab.forge.jlatexmath.Box;
-
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
+
+import org.scilab.forge.jlatexmath.Atom;
+import org.scilab.forge.jlatexmath.Box;
+import org.scilab.forge.jlatexmath.ParseException;
+import org.scilab.forge.jlatexmath.SpaceAtom;
+import org.scilab.forge.jlatexmath.TeXConstants;
+import org.scilab.forge.jlatexmath.TeXEnvironment;
+import org.scilab.forge.jlatexmath.TeXFormula;
+import org.scilab.forge.jlatexmath.TeXParser;
 
 public class FooPackage {
     


### PR DESCRIPTION
* organized imports in all modules (used Eclipse IDE so sometimes just sorted alphabetically but generally speaking there were a lot of unused imports that have been removed).

In just the *jlatexmath* module:

* added serialVersionUID to Exceptions
* removed unused variables
* added generics

I was pretty conservative when removing unused variables. If it had a `//NOPMD` comment or looked like it would trigger a review I left it.

I'll leave cleanup in the other modules for after the #27 work.

Also update README.md to fix appearance of Benchmarks section.