### PR TITLE
Use a scale factor of 100 for deriveFont(); fixes #32

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+jlatexmath (1.0.7)
+	* Fix deformed characters in SVG output by changing font scaling
+
 jlatexmath (1.0.6)
 	* Add TeX style macros \bangle, \brace and \brack.
 

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/CharBox.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/CharBox.java
@@ -80,21 +80,25 @@ public class CharBox extends Box {
         width += italic;
         italic = 0;
     }
-    
+
     public void draw(Graphics2D g2, float x, float y) {
-	drawDebug(g2, x, y);
-	AffineTransform at = g2.getTransform();
+        drawDebug(g2, x, y);
+        AffineTransform at = g2.getTransform();
         g2.translate(x, y);
-	Font font = FontInfo.getFont(cf.fontId);
-        if (size != 1) {
-	    g2.scale(size, size);
-	}
+        Font font = FontInfo.getFont(cf.fontId);
+
+        if (Math.abs(size - TeXFormula.FONT_SCALE_FACTOR) > TeXFormula.PREC) {
+            g2.scale(size / TeXFormula.FONT_SCALE_FACTOR,
+                    size / TeXFormula.FONT_SCALE_FACTOR);
+        }
+
         if (g2.getFont() != font) {
-	    g2.setFont(font);
-	}
-	arr[0] = cf.c;
-	g2.drawChars(arr, 0, 1, 0, 0);
-	g2.setTransform(at);
+            g2.setFont(font);
+        }
+
+        arr[0] = cf.c;
+        g2.drawChars(arr, 0, 1, 0, 0);
+        g2.setTransform(at);
     }
     
     public int getLastFontId() {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFontParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/DefaultTeXFontParser.java
@@ -365,7 +365,8 @@ public class DefaultTeXFontParser {
 
     public static Font createFont(InputStream fontIn, String name) throws ResourceParseException {
         try {
-            Font f = Font.createFont(Font.TRUETYPE_FONT, fontIn).deriveFont(TeXFormula.PIXELS_PER_POINT);
+            Font f = Font.createFont(Font.TRUETYPE_FONT, fontIn)
+                    .deriveFont(TeXFormula.PIXELS_PER_POINT * TeXFormula.FONT_SCALE_FACTOR);
 	    GraphicsEnvironment graphicEnv = GraphicsEnvironment.getLocalGraphicsEnvironment();
 	    /**
 	     * The following fails under java 1.5

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
@@ -105,6 +105,9 @@ public class TeXFormula {
     // point-to-pixel conversion
     public static float PIXELS_PER_POINT = 1f;
 
+    // font scale for deriving
+    public static float FONT_SCALE_FACTOR = 100f;
+
     // for comparing floats with 0
     protected static final float PREC = 0.0000001f;
 


### PR DESCRIPTION
See #32 

There's a tabs/spaces mixup in CharBox.java that needed to be cleared, so the diff is a bit larger than it needs to be