### PR TITLE
Ensure build with java 11 and 12 works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - openjdk7
+  - openjdk11
 
 before_install:
   - sudo apt-get -qq update

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/BigOperatorAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/BigOperatorAtom.java
@@ -89,7 +89,7 @@ public class BigOperatorAtom extends Atom {
      * @param base atom representing the big operator
      * @param under atom representing the under limit
      * @param over atom representing the over limit
-     * @param limits whether limits should be drawn over and under the base (<-> as scripts)
+     * @param limits whether limits should be drawn over and under the base (&lt;-&gt; as scripts)
      */
     public BigOperatorAtom(Atom base, Atom under, Atom over, boolean limits) {
         this(base, under, over);

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/Dummy.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/Dummy.java
@@ -81,16 +81,15 @@ public class Dummy {
     }
 
     /**
-     * Changes the type of the atom
-     *
-     * @param t the new type
+     * Returns the type of the atom
+     * 
+     * @return the type of the atom
      */
     public int getType() {
         return type;
     }
 
     /**
-     *
      * @return the changed type, or the old left type if it hasn't been changed
      */
     public int getLeftType() {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FractionAtom.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/FractionAtom.java
@@ -95,7 +95,7 @@ public class FractionAtom extends Atom {
     }
 
     /**
-     * Depending on noDef, the given thickness and unit will be used (<-> the default
+     * Depending on noDef, the given thickness and unit will be used (&lt;-&gt; the default
      * thickness).
      *
      * @param num the numerator

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXFormula.java
@@ -374,7 +374,7 @@ public class TeXFormula {
     }
 
     /**
-     * @param a formula
+     * @param formula a formula
      * @return a partial TeXFormula containing the valid part of formula
      */
     public static TeXFormula getPartialTeXFormula(String formula) {
@@ -867,7 +867,8 @@ public class TeXFormula {
      * @param formula the formula
      * @param style the style
      * @param size the size
-     * @param transparency, if true the background is transparent
+     * @param fg the foreground color
+     * @param bg the background color
      * @return the generated image
      */
     public static Image createBufferedImage(String formula, int style, float size, Color fg, Color bg) throws ParseException {
@@ -891,10 +892,10 @@ public class TeXFormula {
     }
 
     /**
-     * @param formula the formula
      * @param style the style
      * @param size the size
-     * @param transparency, if true the background is transparent
+     * @param fg the foreground color
+     * @param bg the background color
      * @return the generated image
      */
     public Image createBufferedImage(int style, float size, Color fg, Color bg) throws ParseException {

--- a/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXParser.java
+++ b/jlatexmath/src/main/java/org/scilab/forge/jlatexmath/TeXParser.java
@@ -195,7 +195,7 @@ public class TeXParser {
     }
 
     /**
-     * Create a new TeXParser in the context of an array. When the parser meets a & a new atom is added in the current line and when a \\ is met, a new line is created.
+     * Create a new TeXParser in the context of an array. When the parser meets a &amp; a new atom is added in the current line and when a \\ is met, a new line is created.
      *
      * @param isPartial if true certains exceptions are not thrown
      * @param parseString the string to be parsed
@@ -209,7 +209,7 @@ public class TeXParser {
     }
 
     /**
-     * Create a new TeXParser in the context of an array. When the parser meets a & a new atom is added in the current line and when a \\ is met, a new line is created.
+     * Create a new TeXParser in the context of an array. When the parser meets a &amp; a new atom is added in the current line and when a \\ is met, a new line is created.
      *
      * @param isPartial if true certains exceptions are not thrown
      * @param parseString the string to be parsed
@@ -223,7 +223,7 @@ public class TeXParser {
     }
 
     /**
-     * Create a new TeXParser in the context of an array. When the parser meets a & a new atom is added in the current line and when a \\ is met, a new line is created.
+     * Create a new TeXParser in the context of an array. When the parser meets a &amp; a new atom is added in the current line and when a \\ is met, a new line is created.
      *
      * @param parseString the string to be parsed
      * @param aoa an ArrayOfAtoms where to put the elements
@@ -1413,9 +1413,9 @@ public class TeXParser {
         return Character.isLetter(c);
     }
 
-    /** Test the validity of a character in a command. It must contains only alpha characters and eventually a @ if makeAtletter activated
-     * @param com the command's name
-     * @return the validity of the name
+    /** Test the validity of a character in a command. It must contains only alpha characters and eventually a @ if makeAtletter activated.
+     * @param ch character to test
+     * @return the validity of the character
      */
     public final boolean isValidCharacterInCommand(char ch) {
         return Character.isLetter(ch) || (atIsLetter != 0 && ch == '@');

--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.0</version>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
When building with Java 11 or 12 (openjdk) the build failed with javadoc errors. This PR 
* fixes the javadoc errors (stuff like <, >, & need to be escaped properly in javadoc, and mismatched parameters)
* upgrades *maven-javadoc-plugin* to 3.1.0 (latest)
* adds `openjdk11` to the Travis build matrix

OpenJDK 12 is not available yet on Travis but I confirm the build passes with it also.