### PR TITLE
Update LICENSE in jlatexmath-font-*/LICENSE

### DIFF
--- a/jlatexmath-font-cyrillic/LICENSE
+++ b/jlatexmath-font-cyrillic/LICENSE
@@ -53,4 +53,8 @@ The archive contains several fonts :
 
 4) the fonts cmbsy10.ttf, cmbx10.ttf, cmbxti10.ttf, cmex10.ttf, cmmi10.ttf, cmr10.ttf, cmss10.ttf, cmssbx10.ttf, cmsy10.ttf and cmtt10.ttf are under Knuth License.
 
-You can find a copy of these licenses in the fonts directory.
+5) the greek fonts fcmbipg.ttf, fcmripg.tff, fcmrpg.ttf, fcsropg.ttf, fcmbpg.ttf, fcsbpg.ttf, fctrpg.ttf, fcsrpg.ttf are under GNU GPL version 2.
+
+6) the cyrillic fonts wnbx10.ttf, wnss10.ttf, wnti10.ttf, wnr10.ttf, wnssi10.ttf, wnbxti10.ttf, wnssbx10.ttf, wntt10.ttf are under Knuth License.
+
+You can find a copy of these licenses in org/scilab/forge/jlatexmath/fonts/licences.

--- a/jlatexmath-font-greek/LICENSE
+++ b/jlatexmath-font-greek/LICENSE
@@ -25,6 +25,23 @@ along with this program; see the file COPYING. If not, write to the
 Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 MA 02110-1301, USA.
 
+Linking this library statically or dynamically with other modules 
+is making a combined work based on this library. Thus, the terms 
+and conditions of the GNU General Public License cover the whole 
+combination.
+
+As a special exception, the copyright holders of this library give you 
+permission to link this library with independent modules to produce 
+an executable, regardless of the license terms of these independent 
+modules, and to copy and distribute the resulting executable under terms 
+of your choice, provided that you also meet, for each linked independent 
+module, the terms and conditions of the license of that module. 
+An independent module is a module which is not derived from or based 
+on this library. If you modify this library, you may extend this exception 
+to your version of the library, but you are not obliged to do so. 
+If you do not wish to do so, delete this exception statement from your 
+version.
+
 
 
 The archive contains several fonts :
@@ -36,4 +53,8 @@ The archive contains several fonts :
 
 4) the fonts cmbsy10.ttf, cmbx10.ttf, cmbxti10.ttf, cmex10.ttf, cmmi10.ttf, cmr10.ttf, cmss10.ttf, cmssbx10.ttf, cmsy10.ttf and cmtt10.ttf are under Knuth License.
 
-You can find a copy of these licenses in the fonts directory.
+5) the greek fonts fcmbipg.ttf, fcmripg.tff, fcmrpg.ttf, fcsropg.ttf, fcmbpg.ttf, fcsbpg.ttf, fctrpg.ttf, fcsrpg.ttf are under GNU GPL version 2.
+
+6) the cyrillic fonts wnbx10.ttf, wnss10.ttf, wnti10.ttf, wnr10.ttf, wnssi10.ttf, wnbxti10.ttf, wnssbx10.ttf, wntt10.ttf are under Knuth License.
+
+You can find a copy of these licenses in org/scilab/forge/jlatexmath/fonts/licences.


### PR DESCRIPTION
Ironically enough, the LICENSE file is outdated in `jlatexmath-font-*/LICENSE`, missing in one of them the linking exception, and in the other one the greek & cyrillic font licensing breakdown :P !